### PR TITLE
Fix proxy array usage and deprecated pickel dump

### DIFF
--- a/scripts/skrl/train.py
+++ b/scripts/skrl/train.py
@@ -93,7 +93,7 @@ from isaaclab.envs import (
 )
 from isaaclab.utils.assets import retrieve_file_path
 from isaaclab.utils.dict import print_dict
-from isaaclab.utils.io import dump_pickle, dump_yaml
+from isaaclab.utils.io import dump_yaml
 
 from isaaclab_rl.skrl import SkrlVecEnvWrapper
 
@@ -152,8 +152,6 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
     # dump the configuration into log-directory
     dump_yaml(os.path.join(log_dir, "params", "env.yaml"), env_cfg)
     dump_yaml(os.path.join(log_dir, "params", "agent.yaml"), agent_cfg)
-    dump_pickle(os.path.join(log_dir, "params", "env.pkl"), env_cfg)
-    dump_pickle(os.path.join(log_dir, "params", "agent.pkl"), agent_cfg)
 
     # get checkpoint path (to resume training)
     resume_path = retrieve_file_path(args_cli.checkpoint) if args_cli.checkpoint else None

--- a/source/isaac_lab_tutorial/isaac_lab_tutorial/tasks/direct/isaac_lab_tutorial/isaac_lab_tutorial_env.py
+++ b/source/isaac_lab_tutorial/isaac_lab_tutorial/tasks/direct/isaac_lab_tutorial/isaac_lab_tutorial_env.py
@@ -104,7 +104,7 @@ class IsaacLabTutorialEnv(DirectRLEnv):
 
     def _get_observations(self) -> dict:
         self.velocity = self.robot.data.root_com_vel_w 
-        self.forwards = math_utils.quat_apply(self.robot.data.root_link_quat_w, self.robot.data.FORWARD_VEC_B)
+        self.forwards = math_utils.quat_apply(self.robot.data.root_link_quat_w.torch, self.robot.data.FORWARD_VEC_B.torch)
         # obs = torch.hstack((self.velocity, self.commands))
 
         dot = torch.sum(self.forwards * self.commands, dim=-1, keepdim=True)


### PR DESCRIPTION
Fixes a bug since the introduction of proxy array, arrays need to use `.torch` when being type checked as tensors.
Also fixes deprecated usage of pickle dump which was deprecated.